### PR TITLE
Removes support for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os:
-- linux
 - osx
 language: generic
 sudo: required


### PR DESCRIPTION
This is a problem because not all dependencies support it due to importing UIKit and Foundation.

I would want to revisit this at a later time but maybe not now